### PR TITLE
Fix macos titlebar

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -1,4 +1,9 @@
- #navigation-toolbox, #tabmail-tabs,  #tabmail-arrowscrollbox{ /* Outer tab containers */
+/* On macos, the titlebar has to be made high enough */
+#titlebar {
+ height: 44px;
+}
+
+#navigation-toolbox, #tabmail-tabs,  #tabmail-arrowscrollbox{ /* Outer tab containers */
     min-height: 44px !important;
  }
  


### PR DESCRIPTION
The problem:

<img width="832" alt="Screen Shot 2021-11-04 at 8 39 00 pm" src="https://user-images.githubusercontent.com/23250792/140291318-cfb883c1-d09a-4639-ba68-2cb9b8f55246.png">

My fix:

<img width="831" alt="Screen Shot 2021-11-04 at 8 39 42 pm" src="https://user-images.githubusercontent.com/23250792/140291460-455d6d09-3699-439b-92a5-0a45e48fbbdb.png">